### PR TITLE
Update package.json so that ts types are found.

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,16 @@
   "unpkg": "dist/polyclip-ts.umd.min.js",
   "types": "types/index.d.ts",
   "exports": {
-    "umd": "./dist/polyclip-ts.umd.min.js",
-    "default": "./dist/index.js"
+    ".": {
+      "import": {
+        "default": "./dist/index.js",
+        "types": "./types/index.d.ts"
+      },
+      "require": {
+        "default": "./dist/index.js",
+        "types": "./types/index.d.ts"
+      }
+    } 
   },
   "files": [
     "dist/**/*.js",


### PR DESCRIPTION
Updated "exports" field so that the types are properly found.  
Similar to https://github.com/gxmari007/vite-plugin-eslint/pull/60/files.

Fixing error:
There are types at '.../polyclip-ts/types/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'polyclip-ts' library may need to update its package.json or typings.ts(7016)