### PR TITLE
avoid error when esModuleInterop enabled

### DIFF
--- a/src/vector.ts
+++ b/src/vector.ts
@@ -1,8 +1,8 @@
-import BigNumber from "bignumber.js";
+import * as bn from "bignumber.js";
 
 export interface Vector {
-  x: BigNumber;
-  y: BigNumber;
+  x: bn.BigNumber;
+  y: bn.BigNumber;
 }
 
 /* Cross Product of two vectors with first point at origin */
@@ -30,7 +30,7 @@ export const cosineOfAngle = (pShared: Vector, pBase: Vector, pAngle: Vector) =>
 /* Get the x coordinate where the given line (defined by a point and vector)
  * crosses the horizontal line with the given y coordiante.
  * In the case of parrallel lines (including overlapping ones) returns null. */
-export const horizontalIntersection = (pt: Vector, v: Vector, y: BigNumber) => {
+export const horizontalIntersection = (pt: Vector, v: Vector, y: bn.BigNumber) => {
   if (v.y.isZero()) return null
   return { x: pt.x.plus((v.x.div(v.y)).times(y.minus(pt.y))), y: y }
 }
@@ -38,7 +38,7 @@ export const horizontalIntersection = (pt: Vector, v: Vector, y: BigNumber) => {
 /* Get the y coordinate where the given line (defined by a point and vector)
  * crosses the vertical line with the given x coordiante.
  * In the case of parrallel lines (including overlapping ones) returns null. */
-export const verticalIntersection = (pt: Vector, v: Vector, x: BigNumber) => {
+export const verticalIntersection = (pt: Vector, v: Vector, x: bn.BigNumber) => {
   if (v.x.isZero()) return null
   return { x: x, y: pt.y.plus((v.y.div(v.x)).times(x.minus(pt.x))) }
 }


### PR DESCRIPTION
Hello, there are some errors in turfjs that I believe can solved by using your library, there are several open issues about  it, and it has been mentioned here in #7.

I have been able to get turfjs to build with this library, I am in the process of updating the usages of the `polygon-clipping` project to use this project instead. When I'm finished with that I'll open up a PR there and link it here. It won't be able to be merged until this has been merged and released.

The problem this change solves is it allows typescript to run with `esModuleInterop` set to true. Prior to these changes, the interoperability check would fail like this:

```
> tsc --esModuleInterop --module node16 --moduleResolution node16 --noEmit --strict types.ts

../../node_modules/.pnpm/polyclip-ts@0.16.5/node_modules/polyclip-ts/types/vector.d.ts:3:8 - error TS2709: Cannot use namespace 'BigNumber' as a type```

I'm not a typescript expert, so I don't completely understand the issue, but it seems as though `BigNumber` is already being used as a namespace, and this change just gives it a different name to avoid the conflict.