### PR TITLE
Added config to package.json to let ESM clients know where to find typedefs

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,10 @@
   "types": "types/index.d.ts",
   "exports": {
     "umd": "./dist/polyclip-ts.umd.min.js",
+    "import": {
+      "types": "./types/index.d.ts",
+      "default": "./dist/index.js"
+    },
     "default": "./dist/index.js"
   },
   "files": [


### PR DESCRIPTION
The current location of the typedefs can't be found by modern tools because they infer the wrong directory. This config lists specifically where ESM TS clients should look for index.d.ts

Resolves #7 
Resolves (for ESM) #14
Resolves (for ESM) #18